### PR TITLE
docs: remove godoc link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,6 @@ $ up
 
 ---
 
-[![GoDoc](https://godoc.org/github.com/apex/bins?status.svg)](https://godoc.org/github.com/apex/bins)
 ![](https://img.shields.io/badge/license-MIT-blue.svg)
 ![](https://img.shields.io/badge/status-stable-green.svg)
 


### PR DESCRIPTION
I'm not sure if the Godoc badge is required considering this isn't a Go pkg and the current Godoc doesn't seem necessary